### PR TITLE
chore(alarms): move apigw alarms to static, adjust values

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -159,62 +159,107 @@ variable "alarm_sns_topics" {
 
 variable "alarm_apigw_5xx_errors_threshold" {
   description = "Anomaly detection threshold for HTTP 500 errors"
-  default     = 5
+  default     = 20
 }
 
 variable "alarm_apigw_4xx_errors_threshold" {
   description = "Anomaly detection threshold for HTTP 400 errors"
-  default     = 9
+  default     = 20
 }
 
-variable "alarm_apigw_integration_latency_threshold" {
-  description = "Anomaly detection threshold for Integration latency"
-  default     = 9
-}
-
-variable "alarm_apigw_latency_threshold" {
-  description = "Threshold for api gateway latency"
-  default     = 15
-}
 
 variable "alarm_apigw_5xx_evaluation" {
   description = "Api Gateway 5xx evaluation periods"
-  default     = 2
+  default     = 4
 }
 
 variable "alarm_apigw_5xx_datapoints" {
   description = "Api Gateway 5xx data points to evaluate"
-  default     = 2
+  default     = 4
+}
+
+variable "alarm_apigw_5xx_period" {
+    description = "Api Gateway 5xx period in seconds"
+    default     = 300
+}
+
+variable "alarm_apigw_5xx_statistic" {
+  description = "Api Gateway 5xx statistic"
+  default     = "Sum"
+  type        = string
 }
 
 variable "alarm_apigw_4xx_evaluation" {
   description = "Api Gateway 4xx evaluation periods"
-  default     = 2
+  default     = 4
 }
 
 variable "alarm_apigw_4xx_datapoints" {
   description = "Api Gateway 4xx data points to evaluate"
-  default     = 2
+  default     = 4
+}
+
+variable "alarm_apigw_4xx_period" {
+  description = "Api Gateway 5xx period in seconds"
+  default     = 300
+}
+
+variable "alarm_apigw_4xx_statistic" {
+  description = "Api Gateway 5xx statistic"
+  default     = "Sum"
+  type        = string
+}
+
+variable "alarm_apigw_integration_latency_threshold" {
+  description = "Anomaly detection threshold for Integration latency"
+  default     = 15000
+}
+
+variable "alarm_apigw_latency_threshold" {
+  description = "Threshold for api gateway latency"
+  default     = 15000
 }
 
 variable "alarm_apigw_integration_latency_evaluation" {
   description = "Api Gateway integration latency evaluation periods"
-  default     = 2
+  default     = 4
 }
 
 variable "alarm_apigw_integration_latency_datapoints" {
   description = "Api Gateway integration latency data points to evaluate"
-  default     = 2
+  default     = 4
+}
+
+variable "alarm_apigw_integration_latency_period" {
+  description = "Api Gateway integration latency period in seconds"
+  default     = 300
+}
+
+variable "alarm_apigw_integration_latency_statistic" {
+  description = "Api Gateway integration latency statistic"
+  default     = "Maximum"
+  type        = string
 }
 
 variable "alarm_apigw_latency_evaluation" {
   description = "Api Gateway latency evaluation periods"
-  default     = 2
+  default     = 4
 }
 
 variable "alarm_apigw_latency_datapoints" {
   description = "Api Gateway latency data points to evaluate"
-  default     = 2
+  default     = 4
+}
+
+variable "alarm_apigw_latency_period" {
+  description = "Api Gateway integration latency period in seconds"
+  default     = 300
+}
+
+variable "alarm_apigw_latency_statistic" {
+  description = "Api Gateway integration latency statistic"
+  default     = "Maximum"
+  type        = string
 }
 
 variable "vpc_link_subnets" {

--- a/cloutwatch-alarms.tf
+++ b/cloutwatch-alarms.tf
@@ -2,7 +2,8 @@ resource "aws_cloudwatch_metric_alarm" "apigw_5xx_errors" {
   count = length(var.alarm_sns_topics) > 0 ? 1 : 0
 
   alarm_name                = "${var.environment_name}-apigw-${var.name}-5xx-errors"
-  comparison_operator       = "GreaterThanUpperThreshold"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  threshold                 = var.alarm_apigw_5xx_errors_threshold
   evaluation_periods        = var.alarm_apigw_5xx_evaluation
   datapoints_to_alarm       = var.alarm_apigw_5xx_datapoints
   alarm_description         = "Number of 5xx errors at ${var.name} API Gateway above threshold"
@@ -10,37 +11,26 @@ resource "aws_cloudwatch_metric_alarm" "apigw_5xx_errors" {
   ok_actions                = var.alarm_sns_topics
   insufficient_data_actions = []
   treat_missing_data        = "ignore"
-  threshold_metric_id       = "e1"
 
-  metric_query {
-    id          = "e1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, ${var.alarm_apigw_5xx_errors_threshold})"
-    label       = "5xx Errors (Expected)"
-    return_data = "true"
+  metric_name = "5XXError"
+  namespace   = "AWS/ApiGateway"
+  period      = var.alarm_apigw_5xx_period
+  statistic   = var.alarm_apigw_5xx_statistic
+
+  dimensions = {
+    ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
+    Stage   = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
   }
-
-  metric_query {
-    id          = "m1"
-    return_data = "true"
-    metric {
-      metric_name = "5XXError"
-      namespace   = "AWS/ApiGateway"
-      period      = 300
-      stat        = "Sum"
-
-      dimensions = {
-         ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
-         Stage = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
-      }
-    }
-  }
+  
+  
 }
 
 resource "aws_cloudwatch_metric_alarm" "apigw_4xx_errors" {
   count = length(var.alarm_sns_topics) > 0 ? 1 : 0
 
   alarm_name                = "${var.environment_name}-apigw-${var.name}-4xx-errors"
-  comparison_operator       = "GreaterThanUpperThreshold"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  threshold                 = var.alarm_apigw_4xx_errors_threshold
   evaluation_periods        = var.alarm_apigw_4xx_evaluation
   datapoints_to_alarm       = var.alarm_apigw_4xx_datapoints
   alarm_description         = "Number of 400 errors at ${var.name} API Gateway above threshold"
@@ -48,29 +38,15 @@ resource "aws_cloudwatch_metric_alarm" "apigw_4xx_errors" {
   ok_actions                = var.alarm_sns_topics
   insufficient_data_actions = []
   treat_missing_data        = "ignore"
-  threshold_metric_id       = "e1"
 
-  metric_query {
-    id          = "e1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, ${var.alarm_apigw_4xx_errors_threshold})"
-    label       = "4xx Errors (Expected)"
-    return_data = "true"
-  }
+  metric_name = "4XXError"
+  namespace   = "AWS/ApiGateway"
+  period      = var.alarm_apigw_4xx_period
+  statistic   = var.alarm_apigw_4xx_statistic
 
-  metric_query {
-    id          = "m1"
-    return_data = "true"
-    metric {
-      metric_name = "4XXError"
-      namespace   = "AWS/ApiGateway"
-      period      = 300
-      stat        = "Sum"
-
-      dimensions = {
-         ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
-         Stage = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
-      }
-    }
+  dimensions = {
+    ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
+    Stage   = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
   }
 }
 
@@ -78,7 +54,8 @@ resource "aws_cloudwatch_metric_alarm" "apigw_integration_latency" {
   count = length(var.alarm_sns_topics) > 0 ? 1 : 0
 
   alarm_name                = "${var.environment_name}-apigw-${var.name}-integration-latency"
-  comparison_operator       = "GreaterThanUpperThreshold"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  threshold                 = var.alarm_apigw_integration_latency_threshold
   evaluation_periods        = var.alarm_apigw_integration_latency_evaluation
   datapoints_to_alarm       = var.alarm_apigw_integration_latency_datapoints
   alarm_description         = "Integration latency in ${var.name} API Gateway above threshold"
@@ -86,29 +63,15 @@ resource "aws_cloudwatch_metric_alarm" "apigw_integration_latency" {
   ok_actions                = var.alarm_sns_topics
   insufficient_data_actions = []
   treat_missing_data        = "ignore"
-  threshold_metric_id       = "e1"
 
-  metric_query {
-    id          = "e1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, ${var.alarm_apigw_integration_latency_threshold})"
-    label       = "IntegrationLatency (Expected)"
-    return_data = "true"
-  }
+  metric_name = "IntegrationLatency"
+  namespace   = "AWS/ApiGateway"
+  period      = var.alarm_apigw_integration_latency_period
+  statistic   = var.alarm_apigw_integration_latency_statistic
 
-  metric_query {
-    id          = "m1"
-    return_data = "true"
-    metric {
-      metric_name = "IntegrationLatency"
-      namespace   = "AWS/ApiGateway"
-      period      = 300
-      stat        = "Maximum"
-
-      dimensions = {
-         ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
-         Stage = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
-      }
-    }
+  dimensions = {
+    ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
+    Stage   = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
   }
 }
 
@@ -126,42 +89,13 @@ resource "aws_cloudwatch_metric_alarm" "apigw_latency" {
   insufficient_data_actions = []
   treat_missing_data        = "ignore"
 
-  metric_query {
-    id          = "e1"
-    expression  = "m1-m2"
-    label       = "API Gateway latency"
-    return_data = "true"
-  }
+  metric_name = "Latency"
+  namespace   = "AWS/ApiGateway"
+  period      = var.alarm_apigw_latency_period
+  statistic   = var.alarm_apigw_latency_statistic
 
-  metric_query {
-    id          = "m1"
-    return_data = "false"
-    metric {
-      metric_name = "Latency"
-      namespace   = "AWS/ApiGateway"
-      period      = 300
-      stat        = "Maximum"
-
-      dimensions = {
-         ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
-         Stage = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
-      }
-    }
-  }
-
-  metric_query {
-    id          = "m2"
-    return_data = "false"
-    metric {
-      metric_name = "IntegrationLatency"
-      namespace   = "AWS/ApiGateway"
-      period      = 300
-      stat        = "Maximum"
-
-      dimensions = {
-         ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
-         Stage = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
-      }
-    }
+  dimensions = {
+    ApiName = var.api_type == "http" ? aws_apigatewayv2_api.api[0].name : aws_api_gateway_rest_api.rest_api[0].name
+    Stage   = var.api_type == "http" ? aws_apigatewayv2_stage.stage[0].name : aws_api_gateway_stage.rest_stage[0].stage_name
   }
 }


### PR DESCRIPTION
This pull request updates the CloudWatch alarm configuration for API Gateway by simplifying the alarm definitions and adjusting the thresholds and evaluation parameters. The main changes involve removing anomaly detection and metric math queries, increasing threshold values, and making the alarm configuration more parameterized and consistent.

**Alarm configuration simplification and parameterization:**

* Removed anomaly detection and metric math queries from all API Gateway CloudWatch alarms, switching to direct threshold-based alarms for 4xx, 5xx, latency, and integration latency metrics. [[1]](diffhunk://#diff-e65f57c564bf7dbecc0b3b378820184f2c5855b18f70bdff93be5f98f6192f86L5-L113) [[2]](diffhunk://#diff-e65f57c564bf7dbecc0b3b378820184f2c5855b18f70bdff93be5f98f6192f86L129-L167)
* Added new variables for period, statistic, and threshold values for each alarm type (`alarm_apigw_5xx_period`, `alarm_apigw_5xx_statistic`, `alarm_apigw_4xx_period`, `alarm_apigw_4xx_statistic`, etc.), making the configuration more flexible and explicit.
* Increased default threshold values for 4xx and 5xx errors from single digits to 20, and for latency/integration latency from 9/15 to 15000 (presumably milliseconds), and increased evaluation periods and datapoints to 4 for all alarm types.
* Updated all alarm resources to use the new variables for period, statistic, and threshold, ensuring consistency across alarm definitions. [[1]](diffhunk://#diff-e65f57c564bf7dbecc0b3b378820184f2c5855b18f70bdff93be5f98f6192f86L5-L113) [[2]](diffhunk://#diff-e65f57c564bf7dbecc0b3b378820184f2c5855b18f70bdff93be5f98f6192f86L129-L167)

**Removal of legacy variables and queries:**

* Removed legacy variables and inline metric queries that are no longer used due to the simplified alarm approach. [[1]](diffhunk://#diff-96c0b66accfd9339e88830372e6ae4b26d35d022be660cc372d5a7f348f58823L162-R262) [[2]](diffhunk://#diff-e65f57c564bf7dbecc0b3b378820184f2c5855b18f70bdff93be5f98f6192f86L5-L113) [[3]](diffhunk://#diff-e65f57c564bf7dbecc0b3b378820184f2c5855b18f70bdff93be5f98f6192f86L129-L167)